### PR TITLE
Fix SEO, structured data, llms.txt, and config bugs

### DIFF
--- a/content/extra/robots.txt
+++ b/content/extra/robots.txt
@@ -2,3 +2,4 @@ User-agent: *
 Allow: /
 
 Sitemap: https://duarteocarmo.com/sitemap.xml
+LLMs: https://duarteocarmo.com/llms.txt

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -14,6 +14,7 @@ def load_variable_from(*, filename: str, variable_name: str):
 AUTHOR = "Duarte O.Carmo"
 SITENAME = "Duarte O.Carmo"
 SITEURL = ""
+TWITTER_HANDLE = "@duarteocarmo"
 SITE_DESCRIPTION = (
     "The personal website of Duarte O.Carmo. A technologist/consultant "
     "from Lisbon, now based in Copenhagen."
@@ -78,7 +79,7 @@ STATIC_PATHS = [
 EXTRA_PATH_METADATA = {
     "extra/robots.txt": {"path": "robots.txt"},
     "pdfs/cv.pdf": {"path": "cv.pdf"},
-    "extra/CNAME": {"extra/CNAME": {"path": "CNAME"}},
+    "extra/CNAME": {"path": "CNAME"},
     "html/StateOfVim.html": {"path": "StateOfVim.html"},
 }
 
@@ -120,9 +121,9 @@ SITEMAP = {
     "format": "xml",
     "priorities": {"articles": 0.9, "indexes": 0.5, "pages": 0.9},
     "changefreqs": {
-        "articles": "hourly",
-        "indexes": "hourly",
-        "pages": "hourly",
+        "articles": "monthly",
+        "indexes": "daily",
+        "pages": "weekly",
     },
 }
 BOOKS = load_variable_from(filename="books.py", variable_name="BOOKS")

--- a/plugins/llms/llms.py
+++ b/plugins/llms/llms.py
@@ -55,10 +55,10 @@ class LLMSGenerator:
         about_page = next((p for p in self.context.get("pages", []) if p.slug == "about"), None)
         if not about_page:
             return f"> No description available for {self.sitename}."
-        content = md(about_page.content)
-        content = content.strip().replace("\n", " ")
-
-        return f"> {content}"
+        content = md(about_page.content).strip()
+        # Prefix each line with blockquote marker
+        lines = [f"> {line}" if line.strip() else ">" for line in content.splitlines()]
+        return "\n".join(lines)
 
     def _format_entry(self, item: contents.Content) -> str:
         url = item.url.removesuffix("/")

--- a/theme/templates/header.html
+++ b/theme/templates/header.html
@@ -19,7 +19,7 @@
 
 <meta property="og:locale" content="en_US">
 <meta property="og:site_name" content="{{ SITENAME }}">
-<meta property="og:type" content="website">
+<meta property="og:type" content="{% if article %}article{% else %}website{% endif %}">
 
 <!-- Theme colors -->
 <meta name="theme-color" media="(prefers-color-scheme: light)" content="#fff">
@@ -86,7 +86,7 @@ MathJax.Hub.Config({
 <meta name="description" content="{{ page.description | default(SITE_DESCRIPTION) }}">
 <meta name="twitter:url" content="{{ SITEURL }}/{{ page.url }}">
 <meta name="twitter:title" content="{{ page.title }}">
-<meta name="twitter:description" content="{{ page.title }}">
+<meta name="twitter:description" content="{{ page.description | default(SITE_DESCRIPTION) }}">
 <meta property="og:image" content="{{ SITEURL }}/{{ SITELOGO }}">
 <meta name="twitter:image" content="{{ SITEURL }}/{{ SITELOGO }}">
 <link rel="canonical" href="{{ SITEURL }}/{{ page.url }}">

--- a/theme/templates/structured_data.html
+++ b/theme/templates/structured_data.html
@@ -1,7 +1,7 @@
 {% if article %}
 <script type="application/ld+json">
   {
-    "@context": "http://schema.org",
+    "@context": "https://schema.org",
     "@type": "BlogPosting",
     "name": "{{ article.title }}",
     "headline": "{{ article.title }}",
@@ -38,13 +38,9 @@
     "sameAs": [
       "https://x.com/duarteocarmo",
       "https://github.com/duarteocarmo",
-      "{{ SITEURL }}"
+      "https://linkedin.com/in/duarteocarmo"
     ],
-    "jobTitle": "Technologist/Consultant",
-    "worksFor": {
-      "@type": "Organization",
-      "name": "{{ AUTHOR }}"
-    }
+    "jobTitle": "Technologist/Consultant"
   }
 </script>
 {% endif %}


### PR DESCRIPTION
- Add missing TWITTER_HANDLE to pelicanconf (was blank in twitter:creator tag)
- Fix nested CNAME extra path metadata (was double-nested dict, a no-op)
- Fix sitemap changefreqs: hourly → monthly/daily/weekly (hourly was misleading)
- Fix og:type to emit "article" on article pages instead of always "website"
- Fix twitter:description on pages to use description, not the page title
- Fix schema.org @context from http to https for BlogPosting structured data
- Remove redundant sameAs self-URL and self-referential worksFor from Person schema
- Replace sameAs site URL with LinkedIn profile URL
- Fix llms.py about summary: preserve paragraph structure instead of one-line wall of text
- Add LLMs: directive to robots.txt for llms.txt discoverability

https://claude.ai/code/session_01XqC7hQ9Q6ja6wJYhNUgC9b