### PR TITLE
chore: replace analytics script

### DIFF
--- a/theme/templates/analytics.html
+++ b/theme/templates/analytics.html
@@ -1,8 +1,2 @@
-{% if PLAUSIBLE %}
-<!-- Plausible -->
-<script defer data-domain="duarteocarmo.com" data-api="https://long-firefly-c6e5.duarteocarmo.workers.dev/duarte/event" src="https://long-firefly-c6e5.duarteocarmo.workers.dev/duarte/script.js"></script>
-{% endif %}
-{% if UMAMI %}
-<!-- Umami -->
-<script defer src="https://umami.duarteocarmo.com/script.js" data-website-id="1cedd8bc-b8a4-4fd5-a07c-0616f71c2918"></script>
-{% endif %}
+<!-- Whale analytics -->
+<script defer src="https://whale.duarteocarmo.com/script.js" data-website-id="4dbd2d14-2a51-4cc3-b5c4-45cab61485e8"></script>


### PR DESCRIPTION
## Summary
- Replaces the existing Plausible/Umami analytics template with the new Whale analytics script.

## Verification
- `make help`
- `make build` (fails locally because the photos plugin needs S3/photo env vars: `ValueError: Invalid endpoint:`)
- `uv run pelican content -s /tmp/duarteocarmo_publish_no_photos.py -t theme -o output`
- Verified `output/index.html` contains the Whale script and no old analytics markers.
