### PR TITLE
chore: add data-performance flag to Umami analytics script

### DIFF
--- a/theme/templates/analytics.html
+++ b/theme/templates/analytics.html
@@ -4,5 +4,5 @@
 {% endif %}
 {% if UMAMI %}
 <!-- Umami -->
-<script defer src="https://whale.duarteocarmo.com/script.js" data-website-id="4dbd2d14-2a51-4cc3-b5c4-45cab61485e8"></script>
+<script defer src="https://whale.duarteocarmo.com/script.js" data-website-id="4dbd2d14-2a51-4cc3-b5c4-45cab61485e8" data-performance="true"></script>
 {% endif %}


### PR DESCRIPTION
## Summary
- Adds `data-performance="true"` to the Umami analytics `<script>` tag in `theme/templates/analytics.html`
- Enables Umami's performance data collection (page load timing metrics)

## Test Plan
- [ ] Build the site and verify the Umami script tag in the generated HTML includes `data-performance="true"`